### PR TITLE
 fix: use same-region event forwarding (ENG-5018)

### DIFF
--- a/access/README.md
+++ b/access/README.md
@@ -62,6 +62,7 @@ No modules.
 | <a name="input_stacklet_destination_account_id"></a> [stacklet\_destination\_account\_id](#input\_stacklet\_destination\_account\_id) | Destination account for event forwarding - Provided by Stacklet | `string` | n/a | yes |
 | <a name="input_stacklet_execution_role_arn"></a> [stacklet\_execution\_role\_arn](#input\_stacklet\_execution\_role\_arn) | ARN for the role used by policies Execution - Provided by Stacklet | `string` | n/a | yes |
 | <a name="input_stacklet_external_id"></a> [stacklet\_external\_id](#input\_stacklet\_external\_id) | ID of the Stacklet delpoyment to restrict what can assume the roles - Provided by Stacklet | `string` | n/a | yes |
+| <a name="input_stacklet_target_event_bus_name"></a> [stacklet\_target\_event\_bus\_name](#input\_stacklet\_target\_event\_bus\_name) | Target event bus for event forwarding - Provided by Stacklet | `string` | `"default"` | no |
 
 ## Outputs
 

--- a/access/README.md
+++ b/access/README.md
@@ -59,9 +59,9 @@ No modules.
 | <a name="input_iam_region"></a> [iam\_region](#input\_iam\_region) | Region where IAM resouces should be created. If you don't use us-east-1, set this to a region you do use. | `string` | `"us-east-1"` | no |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | An arbitrary prefix pretended to names of created resources | `any` | n/a | yes |
 | <a name="input_stacklet_assetdb_role_arn"></a> [stacklet\_assetdb\_role\_arn](#input\_stacklet\_assetdb\_role\_arn) | ARN for the role used by AssetDB - Provided by Stacklet | `string` | n/a | yes |
+| <a name="input_stacklet_destination_account_id"></a> [stacklet\_destination\_account\_id](#input\_stacklet\_destination\_account\_id) | Destination account for event forwarding - Provided by Stacklet | `string` | n/a | yes |
 | <a name="input_stacklet_execution_role_arn"></a> [stacklet\_execution\_role\_arn](#input\_stacklet\_execution\_role\_arn) | ARN for the role used by policies Execution - Provided by Stacklet | `string` | n/a | yes |
 | <a name="input_stacklet_external_id"></a> [stacklet\_external\_id](#input\_stacklet\_external\_id) | ID of the Stacklet delpoyment to restrict what can assume the roles - Provided by Stacklet | `string` | n/a | yes |
-| <a name="input_stacklet_host_account_id"></a> [stacklet\_host\_account\_id](#input\_stacklet\_host\_account\_id) | Destination account for event forwarding - Provided by Stacklet | `string` | n/a | yes |
 
 ## Outputs
 

--- a/access/README.md
+++ b/access/README.md
@@ -47,6 +47,7 @@ No modules.
 | [aws_iam_policy_document.execution_extra](https://registry.terraform.io/providers/hashicorp/aws/5.94.0/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.forward](https://registry.terraform.io/providers/hashicorp/aws/5.94.0/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.forward_assume](https://registry.terraform.io/providers/hashicorp/aws/5.94.0/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/5.94.0/docs/data-sources/partition) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/5.94.0/docs/data-sources/region) | data source |
 
 ## Inputs
@@ -58,9 +59,9 @@ No modules.
 | <a name="input_iam_region"></a> [iam\_region](#input\_iam\_region) | Region where IAM resouces should be created. If you don't use us-east-1, set this to a region you do use. | `string` | `"us-east-1"` | no |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | An arbitrary prefix pretended to names of created resources | `any` | n/a | yes |
 | <a name="input_stacklet_assetdb_role_arn"></a> [stacklet\_assetdb\_role\_arn](#input\_stacklet\_assetdb\_role\_arn) | ARN for the role used by AssetDB - Provided by Stacklet | `string` | n/a | yes |
-| <a name="input_stacklet_event_bus_arn"></a> [stacklet\_event\_bus\_arn](#input\_stacklet\_event\_bus\_arn) | ARN for event bus used for event forwarding - Provided by Stacklet | `string` | n/a | yes |
 | <a name="input_stacklet_execution_role_arn"></a> [stacklet\_execution\_role\_arn](#input\_stacklet\_execution\_role\_arn) | ARN for the role used by policies Execution - Provided by Stacklet | `string` | n/a | yes |
 | <a name="input_stacklet_external_id"></a> [stacklet\_external\_id](#input\_stacklet\_external\_id) | ID of the Stacklet delpoyment to restrict what can assume the roles - Provided by Stacklet | `string` | n/a | yes |
+| <a name="input_stacklet_host_account_id"></a> [stacklet\_host\_account\_id](#input\_stacklet\_host\_account\_id) | Destination account for event forwarding - Provided by Stacklet | `string` | n/a | yes |
 
 ## Outputs
 

--- a/access/events_forwarding.tf
+++ b/access/events_forwarding.tf
@@ -54,7 +54,7 @@ resource "aws_cloudwatch_event_target" "forward" {
 
   target_id = "${var.prefix}-event-forward"
   rule      = aws_cloudwatch_event_rule.forward[0].name
-  arn       = var.stacklet_event_bus_arn
+  arn       = local.stacklet_event_bus_arn
   role_arn  = aws_iam_role.forward[0].arn
 }
 
@@ -90,6 +90,6 @@ resource "aws_iam_role_policy" "forward" {
 data "aws_iam_policy_document" "forward" {
   statement {
     actions   = ["events:PutEvents"]
-    resources = [var.stacklet_event_bus_arn]
+    resources = [local.stacklet_event_bus_arn]
   }
 }

--- a/access/events_forwarding.tf
+++ b/access/events_forwarding.tf
@@ -89,7 +89,15 @@ resource "aws_iam_role_policy" "forward" {
 
 data "aws_iam_policy_document" "forward" {
   statement {
-    actions   = ["events:PutEvents"]
-    resources = [local.stacklet_event_bus_arn]
+    actions = ["events:PutEvents"]
+    resources = [
+      provider::aws::arn_build(
+        data.aws_partition.current.partition,
+        "events",
+        "*",
+        var.stacklet_destination_account_id,
+        "event-bus/default"
+      )
+    ]
   }
 }

--- a/access/locals.tf
+++ b/access/locals.tf
@@ -1,5 +1,6 @@
 data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
+data "aws_partition" "current" {}
 
 data "aws_arn" "stacklet_assetdb_role_arn" {
   arn = var.stacklet_assetdb_role_arn
@@ -14,4 +15,5 @@ locals {
   different_target_account = data.aws_caller_identity.current.account_id != data.aws_arn.stacklet_assetdb_role_arn.account
   create_forward_role      = local.create_iam_resources && local.different_target_account
   execution_extra_roles    = local.create_iam_resources ? var.execution_extra_roles : {}
+  stacklet_event_bus_arn   = "arn:${data.aws_partition.current.partition}:events:${data.aws_region.current.name}:${var.stacklet_host_account_id}:event-bus/default"
 }

--- a/access/locals.tf
+++ b/access/locals.tf
@@ -15,5 +15,12 @@ locals {
   different_target_account = data.aws_caller_identity.current.account_id != data.aws_arn.stacklet_assetdb_role_arn.account
   create_forward_role      = local.create_iam_resources && local.different_target_account
   execution_extra_roles    = local.create_iam_resources ? var.execution_extra_roles : {}
-  stacklet_event_bus_arn   = "arn:${data.aws_partition.current.partition}:events:${data.aws_region.current.name}:${var.stacklet_host_account_id}:event-bus/default"
+
+  stacklet_event_bus_arn = provider::aws::arn_build(
+    data.aws_partition.current.partition,
+    "events",
+    data.aws_region.current.name,
+    var.stacklet_destination_account_id,
+    "event-bus/default"
+  )
 }

--- a/access/locals.tf
+++ b/access/locals.tf
@@ -21,6 +21,6 @@ locals {
     "events",
     data.aws_region.current.name,
     var.stacklet_destination_account_id,
-    "event-bus/default"
+    "event-bus/${var.stacklet_target_event_bus_name}"
   )
 }

--- a/access/variables.tf
+++ b/access/variables.tf
@@ -8,8 +8,8 @@ variable "stacklet_execution_role_arn" {
   type        = string
 }
 
-variable "stacklet_event_bus_arn" {
-  description = "ARN for event bus used for event forwarding - Provided by Stacklet"
+variable "stacklet_host_account_id" {
+  description = "Destination account for event forwarding - Provided by Stacklet"
   type        = string
 }
 

--- a/access/variables.tf
+++ b/access/variables.tf
@@ -13,6 +13,13 @@ variable "stacklet_destination_account_id" {
   type        = string
 }
 
+
+variable "stacklet_target_event_bus_name" {
+  description = "Target event bus for event forwarding - Provided by Stacklet"
+  type        = string
+  default     = "default"
+}
+
 variable "stacklet_external_id" {
   description = "ID of the Stacklet delpoyment to restrict what can assume the roles - Provided by Stacklet"
   type        = string

--- a/access/variables.tf
+++ b/access/variables.tf
@@ -8,7 +8,7 @@ variable "stacklet_execution_role_arn" {
   type        = string
 }
 
-variable "stacklet_host_account_id" {
+variable "stacklet_destination_account_id" {
   description = "Destination account for event forwarding - Provided by Stacklet"
   type        = string
 }

--- a/atlantis/dev/access-settings.auto.tfvars
+++ b/atlantis/dev/access-settings.auto.tfvars
@@ -1,7 +1,7 @@
-stacklet_assetdb_role_arn   = "arn:aws:iam::880584957794:role/dev-collector"
-stacklet_execution_role_arn = "arn:aws:iam::880584957794:role/dev-stacklet-execution"
-stacklet_host_account_id    = "880584957794"
-stacklet_external_id        = "external-340c+b540,d21b/43b4:8979=2749@e0d3.13c4"
+stacklet_assetdb_role_arn       = "arn:aws:iam::880584957794:role/dev-collector"
+stacklet_execution_role_arn     = "arn:aws:iam::880584957794:role/dev-stacklet-execution"
+stacklet_destination_account_id = "880584957794"
+stacklet_external_id            = "external-340c+b540,d21b/43b4:8979=2749@e0d3.13c4"
 
 prefix     = "atlantis"
 iam_region = "us-east-2"

--- a/atlantis/dev/access-settings.auto.tfvars
+++ b/atlantis/dev/access-settings.auto.tfvars
@@ -1,6 +1,6 @@
 stacklet_assetdb_role_arn   = "arn:aws:iam::880584957794:role/dev-collector"
 stacklet_execution_role_arn = "arn:aws:iam::880584957794:role/dev-stacklet-execution"
-stacklet_event_bus_arn      = "arn:aws:events:us-east-2:880584957794:event-bus/default"
+stacklet_host_account_id    = "880584957794"
 stacklet_external_id        = "external-340c+b540,d21b/43b4:8979=2749@e0d3.13c4"
 
 prefix     = "atlantis"


### PR DESCRIPTION
[ENG-5018](https://stacklet.atlassian.net/browse/ENG-5018)

Supersedes #6 

### what

Make sure our forwarding rules target event buses in the same region.

### why

Cross-region event forwarding worked by accident until release 2025.03.13. More detail in ENG-5018.

### testing

Local terraform apply with a testing prefix.

### docs

This contains a doc update.