### PR TITLE
chore: combine atlantis projects in a single one with modules

### DIFF
--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -5,6 +5,19 @@ parallel_plan: true
 parallel_apply: true
 
 projects:
+  - name: dev
+    workflow: dev
+    terraform_version: v1.11.3
+    dir: .
+    autoplan:
+      when_modified:
+        - "*.tf*"
+        - "*/*tf."
+        - "*/.terraform.lock.hcl"
+        - "atlantis/dev/**"
+    apply_requirements:
+      - approved
+      - mergeable
   - name: access
     dir: access
     workflow: dev
@@ -47,7 +60,11 @@ workflows:
             name: TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE
             value: "true"
         - run: |
-            cp -a ../atlantis/dev/${PROJECT_NAME}/* .
+            if [ "$PROJECT_NAME" == dev ]; then
+              cp atlantis/dev/main.tf .
+            else
+              cp -a ../atlantis/dev/${PROJECT_NAME}/* .
+            fi
         - init
         - plan
 
@@ -66,5 +83,9 @@ workflows:
             name: TF_PLUGIN_CACHE_MAY_BREAK_DEPENDENCY_LOCK_FILE
             value: "true"
         - run: |
-            cp -a ../atlantis/dev/${PROJECT_NAME}/* .
+            if [ "$PROJECT_NAME" == dev ]; then
+              cp atlantis/dev/main.tf .
+            else
+              cp -a ../atlantis/dev/${PROJECT_NAME}/* .
+            fi
         - apply

--- a/atlantis/dev/main.tf
+++ b/atlantis/dev/main.tf
@@ -1,0 +1,43 @@
+terraform {
+  backend "s3" {
+    bucket  = "stacklet-terraform-ci-backend"
+    key     = "tfstate/dev/terraform-aws-onboarding/tfstate.json"
+    region  = "us-east-2"
+    profile = "Test-Runner"
+  }
+
+  required_version = "~> 1.11.3"
+}
+
+locals {
+  resource_prefix = "atlantis-ci"
+  regions         = ["us-east-1", "us-east-2"]
+
+  # Use the QA deployment as target, to point to a different account.
+  stacklet_external_id        = "b5748e1f-0fa5-47c2-b9e2-84108424dd6a"
+  stacklet_assetdb_role_arn   = "arn:aws:iam::179874453562:role/qa-collector"
+  stacklet_execution_role_arn = "arn:aws:iam::179874453562:role/qa-stacklet-execution"
+  stacklet_platform_role_arn  = "arn:aws:iam::179874453562:role/qa-stacklet-platform"
+}
+
+
+module "access" {
+  source = "./access"
+
+  stacklet_assetdb_role_arn   = local.stacklet_assetdb_role_arn
+  stacklet_execution_role_arn = local.stacklet_execution_role_arn
+  stacklet_external_id        = local.stacklet_external_id
+
+  resource_prefix = local.resource_prefix
+  regions         = local.regions
+}
+
+module "org-read" {
+  source = "./org-read"
+
+  stacklet_assetdb_role_arn  = local.stacklet_assetdb_role_arn
+  stacklet_platform_role_arn = local.stacklet_platform_role_arn
+  stacklet_external_id       = local.stacklet_external_id
+
+  resource_prefix = local.resource_prefix
+}


### PR DESCRIPTION
### what

replace separate atlantis projects with a single one which define modules

### why

simplify setup

### testing

atlantis itself

### docs

n/a
