### PR TITLE
chore: remove atlantis setup

### DIFF
--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -11,9 +11,9 @@ projects:
     dir: .
     autoplan:
       when_modified:
-        - "**/*tf."
+        - "**/*.tf*"
         - "**/.terraform.lock.hcl"
-        - "atlantis/dev/**"
+        - "atlantis/dev/*"
     apply_requirements:
       - approved
       - mergeable

--- a/atlantis/dev/main.tf
+++ b/atlantis/dev/main.tf
@@ -8,36 +8,3 @@ terraform {
 
   required_version = "~> 1.11.3"
 }
-
-locals {
-  resource_prefix = "atlantis"
-  regions         = ["us-east-1", "us-east-2"]
-
-  # Use the QA deployment as target, to point to a different account.
-  stacklet_external_id        = "b5748e1f-0fa5-47c2-b9e2-84108424dd6a"
-  stacklet_assetdb_role_arn   = "arn:aws:iam::179874453562:role/qa-collector"
-  stacklet_execution_role_arn = "arn:aws:iam::179874453562:role/qa-stacklet-execution"
-  stacklet_platform_role_arn  = "arn:aws:iam::179874453562:role/qa-stacklet-platform"
-}
-
-
-module "access" {
-  source = "./access"
-
-  stacklet_assetdb_role_arn   = local.stacklet_assetdb_role_arn
-  stacklet_execution_role_arn = local.stacklet_execution_role_arn
-  stacklet_external_id        = local.stacklet_external_id
-
-  resource_prefix = local.resource_prefix
-  regions         = local.regions
-}
-
-module "org-read" {
-  source = "./org-read"
-
-  stacklet_assetdb_role_arn  = local.stacklet_assetdb_role_arn
-  stacklet_platform_role_arn = local.stacklet_platform_role_arn
-  stacklet_external_id       = local.stacklet_external_id
-
-  resource_prefix = local.resource_prefix
-}


### PR DESCRIPTION
### what

remove atlantis setup to have resources destroyed

### why

we're splitting each module in a separate repo, with its own setup.

### testing

n/a

### docs

n/a
